### PR TITLE
ci: set CNAME file

### DIFF
--- a/.github/workflows/github-pages-deploy-main.yml
+++ b/.github/workflows/github-pages-deploy-main.yml
@@ -19,6 +19,8 @@ jobs:
         run: npm run build
       - name: Make sure to not run Jekyll
         run: touch dist/.nojekyll
+      - name: Set CNAME
+        run: echo "uk-trade-quotas.docs.trade.gov.uk" >> dist/CNAME
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
This is so GitHub knows to show this site for requests to uk-trade-quotas.docs.trade.gov.uk.

The CNAME itself has already been setup.