### PR TITLE
Update the PR preview to use CNAME

### DIFF
--- a/.github/workflows/github-pages-deploy-preview.yml
+++ b/.github/workflows/github-pages-deploy-preview.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           umbrella-dir: preview
           source-dir: dist
+          custom-url: uk-trade-quotas.docs.trade.gov.uk


### PR DESCRIPTION
This change updates the PR preview link to use the CNAME rather than Gihub pages default domain.